### PR TITLE
Implement Open in Remix

### DIFF
--- a/src/_h5ai/public/js/lib/view/view.js
+++ b/src/_h5ai/public/js/lib/view/view.js
@@ -32,6 +32,9 @@ const viewTpl =
                 </li>
             </ul>
             <div id="view-hint"></div>
+            <div style="margin-top: 2rem; text-decoration: underline;">
+                <a id="open_in_remix" href="#" target="_blank" rel="noopener noreferrer">Open repo in Remix</a>
+            </div>
         </div>`;
 const itemTpl =
         `<li class="item">
@@ -46,6 +49,11 @@ const itemTpl =
 const $view = dom(viewTpl);
 const $items = $view.find('#items');
 const $hint = $view.find('#view-hint');
+const $remix_link = $view.find('#open_in_remix');
+const $path = global.window.location.href.split('/');
+const $address = $path[6];
+const $chainId = $path[5];
+$remix_link.attr('href', `https://remix.ethereum.org/?#activate=source-verification&call=source-verification//fetchAndSave//${$address}//${$chainId}`);
 
 
 const cropSize = (size, min, max) => Math.min(max, Math.max(min, size));


### PR DESCRIPTION
This adds, the open in remix link to verified contract repos. Now users, can easily load a contract from the repo to remix
<img width="1440" alt="Screenshot 2021-12-13 at 00 59 31" src="https://user-images.githubusercontent.com/14821816/145734927-765b1632-1578-4133-9a14-75a660e54d35.png">
